### PR TITLE
dockerfile. user dsh replaced by tenantuserid

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.7.0-alpine
 
 # dependency for ssl http
-RUN apk update && apk add openssl 
+RUN apk update && apk add openssl
 
 # dsh dependencies
 COPY dsh /home/dsh/dsh
@@ -12,7 +12,7 @@ RUN apk add alpine-sdk librdkafka librdkafka-dev postgresql-dev
 # create dsh group and user
 ARG tenantuserid
 ENV USERID $tenantuserid
-RUN addgroup -g ${USERID} dsh && adduser -u ${USERID} -G dsh -D -h /home/dsh dsh
+RUN addgroup -g ${USERID} dsh && adduser -u ${USERID} -G dsh -D -h /home/dsh ${USERID}
 
 # install
 RUN pip install googleapis-common-protos confluent-kafka==0.11.4 requests
@@ -20,8 +20,9 @@ RUN pip install googleapis-common-protos confluent-kafka==0.11.4 requests
 # install required packages
 COPY src/ /home/dsh/app/
 RUN chown -R $USERID.$USERID /home/dsh/
+RUN chmod +x /home/dsh/dsh/entrypoint.sh
 
-USER dsh
+USER $USERID
 WORKDIR /home/dsh/app
 
 # entrypoint


### PR DESCRIPTION
tested by running on dsh

- adduition of chmod is in case local permissions were not (already) granted to the entrypoint.sh file , and not granted is the likely default
- user should be tenantuserid per docs. don't know how the alias dsh worked, but for me, also locally , this wasn't working
