### PR TITLE
Update docker base image to latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.0-alpine
+FROM python:3.9.16-alpine
 
 # dependency for ssl http
 RUN apk update && apk add openssl 


### PR DESCRIPTION
Updated docker base image to python:3.9.16-alpine to resolve issues with urllib3 v2.0 no longer supporting LibreSSL 2.7.5.

Sample error trace:
```
Traceback (most recent call last):
  File "command.py", line 9, in <module>
    import requests
  File "/usr/local/lib/python3.7/site-packages/requests/__init__.py", line 43, in <module>
    import urllib3
  File "/usr/local/lib/python3.7/site-packages/urllib3/__init__.py", line 39, in <module>
    "urllib3 v2.0 only supports OpenSSL 1.1.1+, currently "
ImportError: urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with LibreSSL 2.7.5. See: https://github.com/urllib3/urllib3/issues/2168
```